### PR TITLE
A hotfix to skip update if `target['skipNewer']`

### DIFF
--- a/src/config.sample.json
+++ b/src/config.sample.json
@@ -4,12 +4,14 @@
     "reko": {
         "url": "https://rekowiki.tk/wiki/api.php",
         "botName": "<機械人用戶名稱>",
-        "botPassword": "<機械人用戶密碼>"
+        "botPassword": "<機械人用戶密碼>",
+        "skipNewer" true
     },
     "fandom": {
         "url": "https://newkomica-kari.fandom.com/zh-tw/api.php",
         "botName": "<機械人用戶名稱>",
-        "botPassword": "<機械人用戶密碼>"
+        "botPassword": "<機械人用戶密碼>",
+        "skipNewer" true
     },
     "pages": [
         "<你需要用步的頁面>",        


### PR DESCRIPTION
還沒測過，理論上可以動而且向後相容，
如果 fandom 不會亂擋未登入的 https get 的話。
鑑於有人抱怨修改會被蓋掉，實作其他花式同步可能會花比較多時間，
所以先做這個簡單的預防措施。
再麻煩作者大大測試和合併。

A quick hotfix to check datetime of revision
and skip sync if the target's timestamp is
newer than the source's.

example:

{
    "source": "<reko 或是 fandom>",
    "target": [ "<reko 或是 fandom>" ],
    "reko": {
        "url": "https://rekowiki.tk/wiki/api.php",
        "botName": "<機械人用戶名稱>",
        "botPassword": "<機械人用戶密碼>",
        "skipNewer": true
    }
}